### PR TITLE
UHDDevice: extended uhd device make exception handling

### DIFF
--- a/Transceiver52M/device/uhd/UHDDevice.cpp
+++ b/Transceiver52M/device/uhd/UHDDevice.cpp
@@ -635,8 +635,9 @@ int uhd_device::open(const std::string &args, int ref, bool swap_channels)
 	LOGC(DDEV, INFO) << "Using discovered UHD device " << dev_addrs[0].to_string();
 	try {
 		usrp_dev = uhd::usrp::multi_usrp::make(addr);
-	} catch(...) {
+	} catch(uhd::key_error::exception &e) {
 		LOGC(DDEV, ALERT) << "UHD make failed, device " << args;
+		LOGC(DDEV, ALERT) << "UHD make execption output:\n" << e.what();
 		return -1;
 	}
 


### PR DESCRIPTION
Hey guys,

during experimenting with an usrp x310 I had some issues to get osmo-trx-uhd running. It constantly aborted with "UHD make failed, device ...". Since this error message is missing additional information about the source of the failure, I looked up the 'uhd::usrp::multi_usrp::make()' method and added the actual exception to the UHDDevice code. Helped me a lot to nail down my issues with the device. Might help some other people too.