### PR TITLE
remove outdated(?) param that requires a priviledged user(?) that fai…

### DIFF
--- a/doc/examples/osmo-trx-ipc/osmo-trx-ipc.cfg
+++ b/doc/examples/osmo-trx-ipc/osmo-trx-ipc.cfg
@@ -11,8 +11,6 @@ log stderr
 line vty
  no login
 !
-cpu-sched
- policy rr 18
 trx
  bind-ip 127.0.0.1
  remote-ip 127.0.0.1


### PR DESCRIPTION
If I got mailing list correctly,  **policy rr** is obsolete in Osmocom stack.

Maybe I did something wrong, but it required a privileged user for **osmo-trx-ipc**, that caused an issue when opening shm_name provided over Unix socket here https://github.com/osmocom/osmo-trx/blob/3642b5956ccc124cd02f8b08661a36db63c9d2b4/Transceiver52M/device/ipc/IPCDevice.cpp#L101