### PR TITLE
do not swap tx and rx

### DIFF
--- a/Transceiver52M/device/ipc/uhdwrap.cpp
+++ b/Transceiver52M/device/ipc/uhdwrap.cpp
@@ -108,8 +108,8 @@ extern "C" void *uhdwrap_open(struct ipc_sk_if_open_req *open_req)
 	}
 
 	for (unsigned int i = 0; i < open_req->num_chans; i++) {
-		actual_cfg.chans[i].rx_path = open_req->chan_info[i].tx_path;
-		actual_cfg.chans[i].tx_path = open_req->chan_info[i].rx_path;
+		actual_cfg.chans[i].rx_path = open_req->chan_info[i].rx_path;
+		actual_cfg.chans[i].tx_path = open_req->chan_info[i].tx_path;
 	}
 
 	uhd_wrap *uhd_wrap_dev = new uhd_wrap(RadioDevice::NORMAL, &actual_cfg);


### PR DESCRIPTION
I do not know the reason, why rx and tx paths were swapped [here](https://github.com/osmocom/osmo-trx/blob/3642b5956ccc124cd02f8b08661a36db63c9d2b4/Transceiver52M/device/ipc/uhdwrap.cpp#L111), but the commit enabled me (with 2 other PR's) to run the pipeline

osmo-bsc -- osmo-bts-trx -- **osmo-trx-ipc -- ipc-driver-test -- USRP**